### PR TITLE
fix: Ensure full result gets written

### DIFF
--- a/components/status/node/index.mjs
+++ b/components/status/node/index.mjs
@@ -19,8 +19,10 @@ export const externals = {
     }
   },
 
-  showResults(s) {
-    process.stdout.write(s);
+  async showResults(s) {
+    return new Promise((resolve) => {
+      process.stdout.end(s, () => resolve());
+    });
   },
 
   getPlatform() {
@@ -78,9 +80,9 @@ export default (dependencies) => {
   return {
     run,
 
-    main: (root) => {
+    main: async (root) => {
       const json = run(root);
-      externals.showResults(json);
+      await externals.showResults(json);
       return true;
     },
   };

--- a/lib/node/status.mjs
+++ b/lib/node/status.mjs
@@ -3,4 +3,5 @@ import Status from '../../dist/node/status.mjs';
 const { main } = Status({ log: "info" });
 
 const root = process.argv[2] || process.cwd();
-process.exit((main(root)) ? 0 : 1);
+const ret = await main(root);
+process.exit(ret? 0 : 1);


### PR DESCRIPTION
process.stdout.write will return false if the string is too long, i.e.
to indicate backpressure.

These changes switch to using process.stdout.end instead, passing it a
callback that will be called once the entire string is written.