### PR TITLE
Don't scan node_modules for the default configuration

### DIFF
--- a/components/init/node/index.mjs
+++ b/components/init/node/index.mjs
@@ -9,8 +9,10 @@ const GLOB = "!(node_modules)/";
 
 /* c8 ignore start */
 export const externals = {
-  showResults(str) {
-    process.stdout.write(str);
+  async showResults(s) {
+    return new Promise((resolve) => {
+      process.stdout.end(s, () => resolve());
+    });
   },
 };
 /* c8 ignore stop */
@@ -96,9 +98,9 @@ export default (dependencies) => {
   return {
     run,
 
-    main: (root) => {
+    main: async (root) => {
       const json = run(root);
-      externals.showResults(json);
+      await externals.showResults(json);
       return true;
     },
   };

--- a/components/init/node/index.mjs
+++ b/components/init/node/index.mjs
@@ -23,6 +23,11 @@ export default (dependencies) => {
         return false;
       }
 
+      // Don't descend into node_modules
+      if (basename(item.path) === 'node_modules') {
+        return true;
+      }
+
       if (
         glob.sync(pattern, { cwd: item.path, strict: false, silent: true })
           .length !== 0
@@ -66,13 +71,13 @@ export default (dependencies) => {
       }
     });
 
-    return Array.from(paths);
+    return paths;
   };
 
   const run = (root) => {
-    const dirs = findDirsWithFiles(root, "*.map").concat(
-      findDirsWithFiles(root, "+(*.[tj]s|*.[cm]js)"),
-    );
+    const dirsWithSrc = findDirsWithFiles(root, "*.map");
+    findDirsWithFiles(root, "+(*.[tj]s|*.[cm]js)").forEach((v) => dirsWithSrc.add(v))
+    const dirs = Array.from(dirsWithSrc);
 
     const root_len = root.length;
     const config = {

--- a/components/init/node/init.spec.mjs
+++ b/components/init/node/init.spec.mjs
@@ -1,28 +1,32 @@
-import fs from 'fs';
+import fs from "fs";
 import { tmpdir } from "os";
 import { basename } from "path";
 import { strict as assert } from "assert";
 import { mkdir /*, writeFile, symlink*/ } from "fs/promises";
 import { buildTestDependenciesAsync } from "../../build.mjs";
 import YAML from "yaml";
-import {afterEach, beforeEach, describe, it} from "mocha";
+import { afterEach, beforeEach, describe, it } from "mocha";
 import * as sinon from "sinon";
 
-import Init, {externals} from "./index.mjs";
+import Init, { externals } from "./index.mjs";
 
 const dependencies = await buildTestDependenciesAsync(import.meta.url);
 const { main, run } = Init(dependencies);
 
 describe("the init command", () => {
   let directory;
+  let cwd;
   beforeEach(async () => {
     directory = `${tmpdir()}/${Math.random().toString(36).substring(2)}`;
     await mkdir(directory);
     externals.showResults = sinon.stub();
+    cwd = process.cwd();
+    process.chdir(directory);
   });
 
   afterEach(() => {
     sinon.restore();
+    process.chdir(cwd);
   });
 
   describe("main", () => {
@@ -33,22 +37,10 @@ describe("the init command", () => {
 
   describe("run", () => {
     it("creates config when source files are present", () => {
-      const cwd = process.cwd();
-      process.chdir(directory);
-      try {
-        fs.mkdirSync('src');
-        fs.mkdirSync('lib/sub1/sub2', {recursive: true});
-        fs.mkdirSync('noaccess'); fs.chmodSync('noaccess', 0);
-
-        fs.writeFileSync('src/file1.js', '/* empty file */\n');
-        // presence of file2.js should cause tree to get pruned at sub1,
-        // lib/sub1/sub2 shouldn't appear in the config
-        fs.writeFileSync('lib/sub1/file2.js', '/* also empty file */\n');
-        fs.writeFileSync('lib/sub1/sub2/file2.js', '/* one more empty file */\n');
-      }
-      finally {
-        process.chdir(cwd);
-      }
+      fs.mkdirSync("src");
+      fs.mkdirSync("lib/sub1/sub2", { recursive: true });
+      fs.writeFileSync("src/file1.js", "/* empty file */\n");
+      fs.writeFileSync("lib/sub1/file2.js", "/* also empty file */\n");
 
       const result = JSON.parse(run(directory));
       assert.equal(result.filename, "appmap.yml");
@@ -57,11 +49,52 @@ describe("the init command", () => {
       assert.equal(config.name, basename(directory));
       assert.notEqual(config.packages, undefined);
       assert(typeof config.packages, "array");
-      config.packages.sort((a,b) => a.path.localeCompare(b.path));
-      assert.deepEqual(config.packages, [
-        { path: 'lib/sub1' },
-        { path: 'src' },
-      ]);
+      config.packages.sort((a, b) => a.path.localeCompare(b.path));
+      assert.deepEqual(config.packages, [{ path: "lib/sub1" }, { path: "src" }]);
+    });
+
+    it("doesn't descend past directory containing a source file", () => {
+      fs.mkdirSync("lib/sub1/sub2", { recursive: true });
+      // presence of file2.js should cause tree to get pruned at sub1,
+      // lib/sub1/sub2 shouldn't appear in the config
+      fs.writeFileSync("lib/sub1/file2.js", "/* also empty file */\n");
+      fs.writeFileSync("lib/sub1/sub2/file2.js", "/* one more empty file */\n");
+      const result = JSON.parse(run(directory));
+      const config = YAML.parse(result.configuration.contents);
+      config.packages.sort((a, b) => a.path.localeCompare(b.path));
+      assert.deepEqual(config.packages, [{ path: "lib/sub1" }]);
+    });
+
+    it("isn't confused by inaccessible directories", () => {
+      fs.mkdirSync("noaccess");
+      fs.chmodSync("noaccess", 0);
+      const result = JSON.parse(run(directory));
+      assert.ok(result);
+    });
+
+    it("ignores node_modules", () => {
+      // node_modules should get ignored, no matter where they appear.
+      fs.mkdirSync("node_modules");
+      fs.mkdirSync("pkg/node_modules/dep", { recursive: true });
+
+      fs.writeFileSync(
+        "pkg/node_modules/dep/file3.js",
+        "/* empty dep source file */\n",
+      );
+      const result = JSON.parse(run(directory));
+      const config = YAML.parse(result.configuration.contents);
+      assert.equal(config.packages.length, 0);
+    });
+
+    it("doesn't include duplicates", () => {
+      fs.mkdirSync("src");
+      fs.writeFileSync("src/file1.js", "/* empty file */\n");
+      fs.writeFileSync("src/file1.js.map", "/* empty file */\n");
+
+      const result = JSON.parse(run(directory));
+      const config = YAML.parse(result.configuration.contents);
+      assert.equal(config.packages.length, 1);
+      assert.deepEqual(config.packages, [{ path: "src" }]);
     });
   });
 });

--- a/lib/node/init.mjs
+++ b/lib/node/init.mjs
@@ -3,4 +3,5 @@ import Init from '../../dist/node/init.mjs';
 const { main } = Init({ log: "info" });
 
 const root = process.argv[2] || process.cwd();
-process.exit((main(root)) ? 0 : 1);
+const ret = await main(root);
+process.exit(ret? 0 : 1);


### PR DESCRIPTION
When the `init` subcommand scans the project to determine the default configuration, it no longer descends into directories named `node_modules`. Additionally, it no longer adds duplicate entries to the configuration if a directory contains both a `.map` file and a source file.

Also, make sure backpressure from `process.stdout.write` is honored, as was done in 0692a2e for the `show` subcommand.