### PR TITLE
Fix increment location

### DIFF
--- a/components/configuration-accessor/default/index.mjs
+++ b/components/configuration-accessor/default/index.mjs
@@ -85,7 +85,7 @@ export default (dependencies) => {
         return default_package_specifier;
       }
       const options = getSpecifierValue(packages, pathname);
-      logInfo(
+      logDebug(
         "%s source file %j",
         options.enabled ? "Instrumenting" : "Not instrumenting",
         url,

--- a/components/trace/appmap/event/index.mjs
+++ b/components/trace/appmap/event/index.mjs
@@ -52,8 +52,11 @@ export default (dependencies) => {
           if (data_type === "apply") {
             assert(type === "begin", "invalid envent type for apply data type");
             const { function: location } = data;
-            const info = getClassmapClosure(classmap, location);
-            /* c8 ignore start */ if (info === null) {
+            // location is null in the case of a manufactured begin apply event.
+            /* c8 ignore start */
+            const info =
+              location === null ? null : getClassmapClosure(classmap, location);
+            if (info === null) {
               stack.push({ time, shallow: null, id: null });
             } /* c8 ignore stop */ else {
               const { shallow, ...options } = info;


### PR DESCRIPTION
Because mocha tests do not always cut nicely the execution trace, sometimes we have to manufacture some events to make the trace appear complete. This is an important assumption upon which the rest of the trace algorithm rely. In the case of manufactured begin apply event, the location is set to `null` which was not handled correctly. To fix it, I simply add a null check.