### PR TITLE
refactor: check for toString function before serialization

### DIFF
--- a/components/serialization/default/index.mjs
+++ b/components/serialization/default/index.mjs
@@ -114,15 +114,18 @@ export default (dependencies) => {
         }
         serial.index = getIndex(references, counter, value);
         if (method === "toString") {
-          if (typeof value === "function") {
-            serial.print = apply(toString, value, noargs);
-          } else {
+          if (
+            typeof value !== "function" &&
+            typeof value.toString === "function"
+          ) {
             try {
               serial.print = value.toString();
             } catch (error) {
               logWarning("%o.toString() failed with %e", value, error);
               serial.print = apply(toString, value, noargs);
             }
+          } else {
+            serial.print = apply(toString, value, noargs);
           }
         } else {
           assert(


### PR DESCRIPTION
This will remove many of the warnings related to value serialization.