### PR TITLE
fix: Get rid of top-level awaits

### DIFF
--- a/bin/bin.mjs
+++ b/bin/bin.mjs
@@ -18,4 +18,4 @@ if (routes.has(process.argv[2])) {
   process.argv = [process.argv[0], process.argv[1], ...process.argv.slice(3)];
 }
 
-await import(routes.get(verb));
+import(routes.get(verb));

--- a/lib/node/init.mjs
+++ b/lib/node/init.mjs
@@ -3,5 +3,6 @@ import Init from "../../dist/node/init.mjs";
 const { main } = Init({ log: "info" });
 
 const root = process.argv[2] || process.cwd();
-const ret = await main(root);
-process.exit(ret ? 0 : 1);
+main(root).then((ret) => {
+  process.exit(ret ? 0 : 1);
+});

--- a/lib/node/status.mjs
+++ b/lib/node/status.mjs
@@ -3,5 +3,6 @@ import Status from "../../dist/node/status.mjs";
 const { main } = Status({ log: "info" });
 
 const root = process.argv[2] || process.cwd();
-const ret = await main(root);
-process.exit(ret ? 0 : 1);
+main(root).then((ret) => {
+  process.exit(ret ? 0 : 1);
+});


### PR DESCRIPTION
The agent subcommands used by the @appland/appmap CLI need to support
node 12, so they can correctly report that it's not supported by the
agent.