### PR TITLE
fix: node --require needs explicit dot in relative paths

### DIFF
--- a/components/configuration-accessor/default/index.mjs
+++ b/components/configuration-accessor/default/index.mjs
@@ -217,6 +217,7 @@ export default (dependencies) => {
                 "recorder-mocha.mjs",
               ]),
               base,
+              true,
             ),
           ];
           if (isMocha(command)) {
@@ -248,6 +249,7 @@ export default (dependencies) => {
                 "abomination.js",
               ]),
               base,
+              true,
             )}`,
             `--experimental-loader=${pathifyURL(
               appendURLSegmentArray(directory, [
@@ -258,6 +260,7 @@ export default (dependencies) => {
                   : `recorder-${recorder}.mjs`,
               ]),
               base,
+              true,
             )}`,
           ].join(" "),
         };
@@ -276,6 +279,7 @@ export default (dependencies) => {
               `recorder-${recorder}.mjs`,
             ]),
             base,
+            true,
           ),
           ...argv,
         ];

--- a/components/url/default/index.mjs
+++ b/components/url/default/index.mjs
@@ -78,7 +78,7 @@ export default (dependencies) => {
     return pathname.split("/").filter(isNotEmptyString).map(decodeSegment);
   };
 
-  const pathifyURL = (url, base_url) => {
+  const pathifyURL = (url, base_url, dot_prefix = false) => {
     const { pathname, protocol, host } = new _URL(url);
     const {
       pathname: base_pathname,
@@ -108,8 +108,10 @@ export default (dependencies) => {
         base_segments.pop();
         segments.unshift("..");
       }
-      if (segments.length === 0) {
-        segments.push(".");
+      // This generated paths are sometimes given to node's `--require`.
+      // And it relies on having explicit `.` or `..` in relative paths.
+      if (segments.length === 0 || (dot_prefix && segments[0] !== "..")) {
+        segments.unshift(".");
       }
       return segments.join("/");
     }

--- a/components/url/default/index.test.mjs
+++ b/components/url/default/index.test.mjs
@@ -19,11 +19,15 @@ platform = "darwin";
   // pathifyURL //
   assertEqual(pathifyURL("http://host1/foo/bar", "http://host2/qux"), null);
   assertEqual(
-    pathifyURL("http://localhost/foo/bar/q%75x", "http://localhost/foo"),
-    "bar/qux",
+    pathifyURL("http://localhost/foo/bar/q%75x", "http://localhost/foo", true),
+    "./bar/qux",
   );
   assertEqual(
-    pathifyURL("http://localhost/foo//bar/qux/", "http://localhost//foo"),
+    pathifyURL(
+      "http://localhost/foo//bar/qux/",
+      "http://localhost//foo",
+      false,
+    ),
     "bar/qux",
   );
   assertEqual(


### PR DESCRIPTION
This was not detected in tests because relative paths where always prefixed with `..` which is not the case in real npm installation. It probably good to somehow test for that (even if I'm not sure how). But for now, I want to release a fix asap.