### PR TITLE
fix: Fix the version constraints used by status

### DIFF
--- a/components/status/node/index.mjs
+++ b/components/status/node/index.mjs
@@ -40,10 +40,12 @@ export default (dependencies) => {
     const errors = [];
 
     const node_version = externals.getNodeVersion();
-    if (!semver.satisfies(node_version, "14.18.x || 16.13.x || 17.3.x")) {
+
+    const versions = "^14.18.x || ^16.13.x || ^17.3.x";
+    if (!semver.satisfies(node_version, versions)) {
       errors.push({
         level: "error",
-        message: `Unsupported node version ${node_version}`,
+        message: `Unsupported node version ${node_version}, wanted ${versions}`,
       });
     }
 

--- a/components/status/node/status.spec.mjs
+++ b/components/status/node/status.spec.mjs
@@ -15,7 +15,7 @@ describe("the status command", () => {
     externals.getPlatform = sinon.stub().returns("darwin");
     externals.lsPackage = sinon.stub().returns("{}");
     externals.showResults = sinon.stub();
-    externals.getNodeVersion = sinon.stub().returns("14.18.0");
+    externals.getNodeVersion = sinon.stub().returns("14.19.0");
 
     // Make sure we got them all, notCalled will be undefined if the function
     // hasn't been replaced.
@@ -45,10 +45,8 @@ describe("the status command", () => {
       externals.getNodeVersion = sinon.stub().returns(node_version);
       const result = JSON.parse(run(process));
       assert(externals.getNodeVersion.calledOnce);
-      assert.deepEqual(result.errors[0], {
-        level: "error",
-        message: `Unsupported node version ${node_version}`,
-      });
+      assert.equal(result.errors[0].level, 'error');
+      assert.match(result.errors[0].message, new RegExp(`Unsupported node version ${node_version}`))
     });
 
     describe("mocha support", () => {


### PR DESCRIPTION
The changes update the version constraints used by the "status"
subcommand. They were (much) too specific, causing installations to
fail.

Also, update the message to show the new constraints.