### PR TITLE
Reduce warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ The most frequently used `appmap-agent-js` parameters are:
     - **Warning:** AppMaps recorded with the `process` recorder can be excessively large and noisy.
 - `--command="_start command_"` : alternate method of specifying the app- or tests-starting command, wrapped in quotes
 - `--log-level=[debug|info|warning|error]` :  defaults to `info`
+- `--log-file=_file_` : location of log file, defaults to `stderr` 
 - `--output-dir=_directory_` : location of recorded AppMap files, default is `tmp/appmap` or `tmp/appmap/mocha`
-
 
 ### Example
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -35,15 +35,18 @@ The configuration format is detailed [here](#configuration).
   npx appmap-agent-js --name my-appmap-name --app my-app-name
   ```
   Aliases:
-  | Alias          | Corresponding Name |
-  |----------------|--------------------|
-  | `--log-level`  | `--log`            |
-  | `--output-dir` | `--output`         |
+  | Alias               | Corresponding Name     |
+  |---------------------|------------------------|
+  | `--log-level`       | `log.level`            |
+  | `--log-file`        | `log.file`             |
+  | `--app-port`        | `intercept-track-port` |
+  | `--alt-remote-port` | `track-port`           |
+  | `--output-dir`      | `output`               |
   In addition, the command can be encoded as positional argument.
   For instance, these commands have the same effect:
   ```sh
   npx appmap-agent-js -- node main.js
-  npx appmap-agent-js --command: 'node main.js'
+  npx appmap-agent-js --command 'node main.js'
   ```
 * *Environment variables*
     * `APPMAP_CONFIGURATION_PATH`: path to the configuration file, default: `./appmap.yml`.

--- a/build/schema/schema.yml
+++ b/build/schema/schema.yml
@@ -239,6 +239,30 @@
         - {$ref: stdio-stream}
         - {$ref: stdio-stream}
 
+- $id: log
+  anyOf:
+    - {$ref: log-level}
+    - type: object
+      additionalProperties: false
+      properties:
+        level: {$ref: log-level}
+        file:
+          anyOf:
+            - $ref: path
+            - const: 1
+            - const: 2
+
+- $id: cooked-log
+  type: object
+  additionalProperties: false
+  properties:
+    level: {$ref: log-level}
+    file:
+      anyOf:
+        - $ref: url
+        - const: 1
+        - const: 2
+
 - $id: env
   type: object
   additionalProperties: false
@@ -406,7 +430,7 @@
       properties:
         message: {type: boolean}
         appmap: {type: boolean}
-    log: {$ref: log-level}
+    log: {$ref: log}
     host: {const: localhost}
     session: {$ref: basename}
     trace-port: {$ref: port}
@@ -530,7 +554,7 @@
         - const: null
         - $ref: agent
     repository: {$ref: repository}
-    log: {$ref: log-level}
+    log: {$ref: cooked-log}
     host: {const: localhost}
     session:
       anyOf:

--- a/components/abomination/default/index.mjs
+++ b/components/abomination/default/index.mjs
@@ -54,7 +54,7 @@ export default (dependencies) => {
               await unlinkAsync(link);
               await symlinkAsync(`${path}.cjs`, link, "file");
             })(),
-            "Something went wrong when resolving the missing file extension issue >> %e",
+            "Something went wrong when resolving the missing file extension issue >> %O",
           );
         }
       }

--- a/components/batch/default/index.mjs
+++ b/components/batch/default/index.mjs
@@ -71,7 +71,7 @@ export default (dependencies) => {
               resolve({ signal, status });
             });
           }),
-          "Child error %j >> %e",
+          "Child error %j >> %O",
           description,
         );
         subprocess = null;

--- a/components/configuration-accessor/default/index.mjs
+++ b/components/configuration-accessor/default/index.mjs
@@ -9,7 +9,7 @@ export default (dependencies) => {
     util: { assert, coalesce },
     url: { pathifyURL, urlifyPath, appendURLSegmentArray },
     expect: { expect, expectSuccess },
-    log: { logDebug, logInfo, logGuardWarning },
+    log: { logGuardWarning },
     repository: {
       extractRepositoryDependency,
       extractRepositoryHistory,
@@ -173,20 +173,10 @@ export default (dependencies) => {
       }
       return configuration;
     },
-    isConfigurationEnabled: ({ processes, main }) => {
-      const enabled = main === null || getSpecifierValue(processes, main);
-      logInfo(`%s %s.`, enabled ? "Recording" : "Bypassing", main);
-      return enabled;
-    },
-    getConfigurationPackage: ({ packages }, url) => {
-      const options = getSpecifierValue(packages, url);
-      logDebug(
-        "%s source file %j",
-        options.enabled ? "Instrumenting" : "Not instrumenting",
-        url,
-      );
-      return options;
-    },
+    isConfigurationEnabled: ({ processes, main }) =>
+      main === null || getSpecifierValue(processes, main),
+    getConfigurationPackage: ({ packages }, url) =>
+      getSpecifierValue(packages, url),
     getConfigurationScenarios: (configuration) => {
       const { scenarios, scenario } = configuration;
       const regexp = expectSuccess(

--- a/components/configuration-accessor/default/index.mjs
+++ b/components/configuration-accessor/default/index.mjs
@@ -181,7 +181,7 @@ export default (dependencies) => {
       const { scenarios, scenario } = configuration;
       const regexp = expectSuccess(
         () => new _RegExp(scenario, "u"),
-        "Scenario configuration field is not a valid regexp: %j >> %e",
+        "Scenario configuration field is not a valid regexp: %j >> %O",
         scenario,
       );
       return scenarios

--- a/components/configuration-environment/default/index.mjs
+++ b/components/configuration-environment/default/index.mjs
@@ -16,7 +16,7 @@ export default (dependencies) => {
       const { APPMAP_CONFIGURATION: content } = env;
       const configuration = expectSuccess(
         () => parseJSON(content),
-        "failed to parse 'APPMAP_CONFIGURATION' environment variable >> %e",
+        "failed to parse 'APPMAP_CONFIGURATION' environment variable >> %O",
       );
       validateConfiguration(configuration);
       return configuration;

--- a/components/configuration-process/node/index.mjs
+++ b/components/configuration-process/node/index.mjs
@@ -43,7 +43,7 @@ export default (dependencies) => {
       const { code } = error;
       expect(
         code === "ENOENT",
-        "Cannot read configuration file at %j >> %e",
+        "Cannot read configuration file at %j >> %O",
         url,
         error,
       );
@@ -51,7 +51,7 @@ export default (dependencies) => {
     }
     return expectSuccess(
       () => parse(content),
-      "Failed to parse configuration file at %j >> %e",
+      "Failed to parse configuration file at %j >> %O",
       url,
     );
   };

--- a/components/configuration-process/node/index.mjs
+++ b/components/configuration-process/node/index.mjs
@@ -57,7 +57,6 @@ export default (dependencies) => {
   };
 
   const aliases = new _Map([
-    ["log-level", "log"],
     ["output-dir", "output"],
     ["app-port", "intercept-track-port"],
     ["alt-remote-port", "track-port"],
@@ -114,6 +113,15 @@ export default (dependencies) => {
       if (transformers.has(key)) {
         config[key] = transformers.get(key)(config[key]);
       }
+    }
+    config.log = {};
+    if (hasOwnProperty(config, "log-level")) {
+      config.log.level = config["log-level"];
+      delete config["log-level"];
+    }
+    if (hasOwnProperty(config, "log-file")) {
+      config.log.file = config["log-file"];
+      delete config["log-file"];
     }
     return config;
   };

--- a/components/configuration-process/node/index.test.mjs
+++ b/components/configuration-process/node/index.test.mjs
@@ -48,7 +48,8 @@ assertThrow(
     argv: [
       ["node", "agent.mjs"],
       ["--track-port", "8080"],
-      ["--log-level", "error"],
+      ["--log-level", "warning"],
+      ["--log-file", "1"],
       ["--map-name", "name2"],
       ["--packages", "'lib/*.js'"],
       ["--package", "'test/*.js'"],
@@ -64,7 +65,10 @@ assertThrow(
     {
       track_port: 8080,
       app_name: "app",
-      log: "error",
+      log: {
+        level: "warning",
+        file: 1,
+      },
       map_name: "name2",
       command: {
         script: null,

--- a/components/configuration/default/index.mjs
+++ b/components/configuration/default/index.mjs
@@ -74,6 +74,17 @@ export default (dependencies) => {
     }));
   };
 
+  const normalizeLog = (log, base) => {
+    if (typeof log === "string") {
+      log = { level: log };
+    }
+    log = { level: "error", file: 2, ...log };
+    if (typeof log.file !== "number") {
+      log.file = urlifyPath(log.file, base);
+    }
+    return log;
+  };
+
   const normalizePort = (port, base) => {
     if (typeof port === "string" && port !== "") {
       port = urlifyPath(port, base);
@@ -237,8 +248,8 @@ export default (dependencies) => {
       normalize: identity,
     },
     log: {
-      extend: overwrite,
-      normalize: identity,
+      extend: assign,
+      normalize: normalizeLog,
     },
     host: {
       extend: overwrite,
@@ -419,7 +430,10 @@ export default (dependencies) => {
         appmap: false,
         message: false,
       },
-      log: "info",
+      log: {
+        level: "error",
+        file: 2,
+      },
       output: {
         directory: null,
         basename: null,

--- a/components/configuration/default/index.test.mjs
+++ b/components/configuration/default/index.test.mjs
@@ -105,6 +105,18 @@ assertDeepEqual(extend("language", { name: "foo", version: "bar" }), {
   version: "bar",
 });
 
+// log //
+
+assertDeepEqual(extend("log", "warning"), {
+  level: "warning",
+  file: 2,
+});
+
+assertDeepEqual(extend("log", { file: "log" }, "file:///base"), {
+  level: "error",
+  file: "file:///base/log",
+});
+
 // recording //
 
 assertDeepEqual(extend("recording", "foo.bar"), {

--- a/components/expect-inner/default/index.test.mjs
+++ b/components/expect-inner/default/index.test.mjs
@@ -33,7 +33,7 @@ try {
 }
 
 assertEqual(
-  expectSuccess(() => 123, "%e"),
+  expectSuccess(() => 123, "%O"),
   123,
 );
 
@@ -42,19 +42,19 @@ try {
     () => {
       throw new Error("foo");
     },
-    "%s %e",
+    "%s %O",
     "bar",
   );
   assertFail();
 } catch ({ message }) {
-  assertEqual(message, "bar foo");
+  assertEqual(message, "bar Error: foo");
 }
 
-await expectSuccessAsync(Promise.resolve(123), "%e");
+await expectSuccessAsync(Promise.resolve(123), "%O");
 
 try {
-  await expectSuccessAsync(Promise.reject(new Error("foo")), "%s %e", "bar");
+  await expectSuccessAsync(Promise.reject(new Error("foo")), "%s %O", "bar");
   assertFail();
 } catch ({ message }) {
-  assertEqual(message, "bar foo");
+  assertEqual(message, "bar Error: foo");
 }

--- a/components/expect/debug/index.test.mjs
+++ b/components/expect/debug/index.test.mjs
@@ -7,7 +7,7 @@ const { expect, expectSuccess, expectSuccessAsync } = Expect(
 );
 assertEqual(expect(true, "%s", "foo"), undefined);
 assertEqual(
-  expectSuccess(() => 123, "%e"),
+  expectSuccess(() => 123, "%O"),
   123,
 );
-await expectSuccessAsync(Promise.resolve(123), "%e");
+await expectSuccessAsync(Promise.resolve(123), "%O");

--- a/components/hook-query/node/require.mjs
+++ b/components/hook-query/node/require.mjs
@@ -14,7 +14,7 @@ export default (dependencies) => {
       try {
         return createRequire(url)(name);
       } catch (error) {
-        logWarning("Could not load %j from %j >> %e", name, directory, error);
+        logWarning("Could not load %j from %j >> %O", name, directory, error);
         return null;
       }
     },

--- a/components/hook-response/node/index.mjs
+++ b/components/hook-response/node/index.mjs
@@ -212,7 +212,7 @@ export default (dependencies) => {
         recorder,
         regexp: expectSuccess(
           () => new _RegExp(intercept_track_port, "u"),
-          "Failed to compile the 'intercept-track-port' configuration field %j as regexp >> %e",
+          "Failed to compile the 'intercept-track-port' configuration field %j as regexp >> %O",
           intercept_track_port,
         ),
       };

--- a/components/instrumentation/default/index.mjs
+++ b/components/instrumentation/default/index.mjs
@@ -83,6 +83,7 @@ export default (dependencies) => {
                 parseEstree(content, {
                   allowHashBang: true,
                   sourceType: type,
+                  allowAwaitOutsideFunction: type === "module",
                   ecmaVersion: configuration.language.version,
                   locations: true,
                 }),

--- a/components/instrumentation/default/index.mjs
+++ b/components/instrumentation/default/index.mjs
@@ -86,7 +86,7 @@ export default (dependencies) => {
                   ecmaVersion: configuration.language.version,
                   locations: true,
                 }),
-              "failed to parse file %j >> %e",
+              "failed to parse file %j >> %O",
               url,
             ),
             {

--- a/components/instrumentation/default/index.mjs
+++ b/components/instrumentation/default/index.mjs
@@ -42,6 +42,11 @@ export default (dependencies) => {
             exclude,
             "inline-source": inline,
           } = getConfigurationPackage(configuration, url);
+          logDebug(
+            "%s source file %j",
+            enabled ? "Instrumenting" : "Not instrumenting",
+            url,
+          );
           return {
             head: enabled,
             body: {

--- a/components/instrumentation/default/visit.mjs
+++ b/components/instrumentation/default/visit.mjs
@@ -199,7 +199,7 @@ export default (dependencies) => {
     expect: { expect },
     util: { assert, hasOwnProperty, coalesce },
     source: { mapSource },
-    log: { logGuardWarning },
+    log: { logGuardDebug },
     location: { stringifyLocation, getLocationFileURL },
   } = dependencies;
 
@@ -492,7 +492,7 @@ export default (dependencies) => {
           },
         } = node;
         const location = mapSource(mapping, line, column);
-        logGuardWarning(
+        logGuardDebug(
           location === null,
           "Missing source map at file %j at line %j at column %j",
           url,

--- a/components/instrumentation/default/visit.mjs
+++ b/components/instrumentation/default/visit.mjs
@@ -307,6 +307,12 @@ export default (dependencies) => {
     body: [
       makeVariableDeclaration("let", [
         makeVariableDeclarator(
+          makeIdentifier(`${runtime}_JUMP`),
+          makeLiteral(null),
+        ),
+      ]),
+      makeVariableDeclaration("let", [
+        makeVariableDeclarator(
           makeIdentifier(`${runtime}_JUMP_ID`),
           makeLiteral(null),
         ),

--- a/components/instrumentation/default/visit.test.mjs
+++ b/components/instrumentation/default/visit.test.mjs
@@ -218,7 +218,8 @@ assertEqual(
   ),
   normalize(
     `
-    let $_JUMP_ID = null
+    let $_JUMP = null;
+    let $_JUMP_ID = null;
     try { } catch ($_ERROR) {
       if ($_JUMP_ID !== null) {
         $.recordAfterJump($_JUMP_ID);

--- a/components/log-inner/write-sync/index.mjs
+++ b/components/log-inner/write-sync/index.mjs
@@ -1,17 +1,22 @@
 // NB: Synchronous loggin is important to avoid
 //  infinite loop when async hooks are enabled.
-import { writeSync } from "fs";
+import { openSync, writeSync } from "fs";
+
+const { parse: parseJSON } = JSON;
 
 export default (dependencies) => {
   const {
-    util: { format },
+    util: { format, hasOwnProperty },
   } = dependencies;
-  const generateLog = (name) => {
-    const fd = name === "WARNING" || name === "ERROR" ? 2 : 1;
-    return (template, ...values) => {
+  const file = hasOwnProperty(process.env, "APPMAP_LOG_FILE")
+    ? parseJSON(process.env.APPMAP_LOG_FILE)
+    : 2;
+  const fd = typeof file === "number" ? file : openSync(new URL(file), "w");
+  const generateLog =
+    (name) =>
+    (template, ...values) => {
       writeSync(fd, `APPMAP-${name} ${format(template, values)}\n`);
     };
-  };
   return {
     logDebug: generateLog("DEBUG"),
     logInfo: generateLog("INFO"),

--- a/components/log-inner/write-sync/index.test.mjs
+++ b/components/log-inner/write-sync/index.test.mjs
@@ -1,5 +1,15 @@
 import { buildTestDependenciesAsync } from "../../build.mjs";
+import { getFreshTemporaryURL } from "../../__fixture__.mjs";
 import LogInner from "./index.mjs";
 
-const { logInfo } = LogInner(await buildTestDependenciesAsync(import.meta.url));
-logInfo("foo %s", "bar");
+const testAsync = async () => {
+  const { logInfo } = LogInner(
+    await buildTestDependenciesAsync(import.meta.url),
+  );
+  logInfo("foo %s", "bar");
+};
+
+await testAsync();
+
+process.env.APPMAP_LOG_FILE = JSON.stringify(getFreshTemporaryURL());
+await testAsync();

--- a/components/receptor-file/default/index.mjs
+++ b/components/receptor-file/default/index.mjs
@@ -83,7 +83,7 @@ export default (dependencies) => {
       counter += 1;
       url = appendURLSegment(
         directory,
-        makeSegment(`${basename}-${_String(counter)}${extension}`),
+        makeSegment(`${basename}-${_String(counter)}${extension}`, "-"),
       );
     }
     urls.add(url);

--- a/components/receptor-file/default/index.mjs
+++ b/components/receptor-file/default/index.mjs
@@ -34,7 +34,7 @@ export default (dependencies) => {
       const { code } = error;
       expect(
         code === "ENOENT",
-        "cannot read directory status %j >> %e",
+        "cannot read directory status %j >> %O",
         directory,
         error,
       );

--- a/components/receptor-file/default/index.mjs
+++ b/components/receptor-file/default/index.mjs
@@ -16,7 +16,7 @@ export default (dependencies) => {
     path: { makeSegment },
     url: { appendURLSegment },
     util: { assert },
-    log: { logInfo, logError },
+    log: { logDebug, logInfo, logError },
     expect: { expect },
     service: { openServiceAsync, closeServiceAsync, getServicePort },
     backend: {
@@ -159,7 +159,7 @@ export default (dependencies) => {
         });
       });
       const trace_service = await openServiceAsync(server, trace_port);
-      logInfo("Trace port: %j", getServicePort(trace_service));
+      logDebug("Trace port: %j", getServicePort(trace_service));
       return trace_service;
     },
     adaptReceptorConfiguration: (service, configuration) =>

--- a/components/receptor-http/default/index.mjs
+++ b/components/receptor-http/default/index.mjs
@@ -11,7 +11,7 @@ export default (dependencies) => {
   const {
     util: { assert },
     http: { generateRespond },
-    log: { logInfo, logError },
+    log: { logDebug, logError },
     service: { openServiceAsync, closeServiceAsync, getServicePort },
     backend: {
       createBackend,
@@ -55,7 +55,7 @@ export default (dependencies) => {
       track_server.on(
         "request",
         generateRespond(async (method, path, body) => {
-          logInfo("Received remote recording request: %s %s", method, path);
+          logDebug("Received remote recording request: %s %s", method, path);
           const parts = path.split("/");
           if (parts.length !== 3 || parts[0] !== "") {
             return {
@@ -169,8 +169,8 @@ export default (dependencies) => {
       });
       const trace_service = await openServiceAsync(trace_server, trace_port);
       const track_service = await openServiceAsync(track_server, track_port);
-      logInfo("Trace port: %j", getServicePort(trace_service));
-      logInfo("Track port: %j", getServicePort(track_service));
+      logDebug("Trace port: %j", getServicePort(trace_service));
+      logDebug("Track port: %j", getServicePort(track_service));
       return { trace_service, track_service };
     },
     adaptReceptorConfiguration: (

--- a/components/recorder-api/default/index.mjs
+++ b/components/recorder-api/default/index.mjs
@@ -36,7 +36,7 @@ export default (dependencies) => {
     url = _String(url);
     expectSuccess(
       () => new _URL(url),
-      "the second argument of appmap.recordScript should be a valid url, got: %j >> %e",
+      "the second argument of appmap.recordScript should be a valid url, got: %j >> %O",
       url,
     );
     return { type, url, content };

--- a/components/recorder-cli/default/index.mjs
+++ b/components/recorder-cli/default/index.mjs
@@ -18,9 +18,15 @@ export default (dependencies) => {
   } = dependencies;
   return {
     createRecorder: (process, configuration) => {
-      logInfo("Caught process %j", process.pid);
       configuration = extendConfigurationNode(configuration, process);
-      if (isConfigurationEnabled(configuration)) {
+      const enabled = isConfigurationEnabled(configuration);
+      logInfo(
+        "%s process #%j -- %j",
+        enabled ? "Recording" : "*Not* recording",
+        process.pid,
+        process.argv,
+      );
+      if (enabled) {
         const agent = openAgent(configuration);
         const hooking = hook(agent, configuration);
         const tracks = new Set();

--- a/components/repository/node/git.mjs
+++ b/components/repository/node/git.mjs
@@ -28,7 +28,7 @@ export default (dependencies) => {
     const error = coalesce(result, "error", null);
     expect(
       error === null,
-      `command %j on cwd %j threw an error >> %e`,
+      `command %j on cwd %j threw an error >> %O`,
       command,
       url,
       error || { message: "dummy" },
@@ -74,7 +74,7 @@ export default (dependencies) => {
       if (
         !expectSuccess(
           () => readdirSync(new _URL(url)),
-          "could not read repository directory %j >> %e",
+          "could not read repository directory %j >> %O",
           url,
         ).includes(".git")
       ) {

--- a/components/repository/node/index.mjs
+++ b/components/repository/node/index.mjs
@@ -21,7 +21,7 @@ export default (dependencies) => {
       const { code } = { code: null, ...error };
       expect(
         code === "ENOENT",
-        "failed to attempt reading package.json >> %e",
+        "failed to attempt reading package.json >> %O",
         error,
       );
       return false;
@@ -35,14 +35,14 @@ export default (dependencies) => {
         "utf8",
       );
     } catch (error) {
-      logWarning("Cannot read package.json file at %j >> %e", url, error);
+      logWarning("Cannot read package.json file at %j >> %O", url, error);
       return null;
     }
     let json;
     try {
       json = parseJSON(content);
     } catch (error) {
-      logWarning("Failed to parse package.json file at %j >> %e", url, error);
+      logWarning("Failed to parse package.json file at %j >> %O", url, error);
       return null;
     }
     const { name, version, homepage } = {
@@ -75,7 +75,7 @@ export default (dependencies) => {
       let url = pathToFileURL(
         expectSuccess(
           () => resolve(segments.join("/")),
-          "could not resolve %j from %j >> %e",
+          "could not resolve %j from %j >> %O",
           segments,
           home,
         ),

--- a/components/serialization/default/index.mjs
+++ b/components/serialization/default/index.mjs
@@ -121,7 +121,7 @@ export default (dependencies) => {
             try {
               serial.print = value.toString();
             } catch (error) {
-              logWarning("%o.toString() failed with %e", value, error);
+              logWarning("%o.toString() failure >> %O", value, error);
               serial.print = apply(toString, value, noargs);
             }
           } else {

--- a/components/serialization/default/index.mjs
+++ b/components/serialization/default/index.mjs
@@ -124,6 +124,10 @@ export default (dependencies) => {
               logDebug("%o.toString() failure >> %O", value, error);
               serial.print = apply(toString, value, noargs);
             }
+            if (typeof serial.print !== "string") {
+              logDebug("%o.toString() returned a non-string result");
+              serial.print = apply(toString, value, noargs);
+            }
           } else {
             serial.print = apply(toString, value, noargs);
           }

--- a/components/serialization/default/index.mjs
+++ b/components/serialization/default/index.mjs
@@ -17,7 +17,7 @@ const noargs = [];
 export default (dependencies) => {
   const {
     util: { assert, hasOwnProperty, coalesce, incrementCounter, createCounter },
-    log: { logWarning },
+    log: { logDebug },
   } = dependencies;
   const empty = symbolFor("APPMAP_EMPTY_MARKER");
   const wellknown = new _Set(
@@ -52,7 +52,7 @@ export default (dependencies) => {
         if (typeof name === "string") {
           return name;
         }
-        logWarning("failed to extract constructor name from %o", object);
+        logDebug("failed to extract constructor name from %o", object);
         return null;
       }
       object = getPrototypeOf(object);
@@ -121,7 +121,7 @@ export default (dependencies) => {
             try {
               serial.print = value.toString();
             } catch (error) {
-              logWarning("%o.toString() failure >> %O", value, error);
+              logDebug("%o.toString() failure >> %O", value, error);
               serial.print = apply(toString, value, noargs);
             }
           } else {

--- a/components/serialization/default/index.test.mjs
+++ b/components/serialization/default/index.test.mjs
@@ -150,6 +150,22 @@ assertDeepEqual(
     print: "[object Object]",
   },
 );
+assertDeepEqual(
+  testSerialize(
+    {
+      method: "toString",
+      "include-constructor-name": false,
+    },
+    {
+      toString: () => 123,
+    },
+  ),
+  {
+    type: "object",
+    index: 1,
+    print: "[object Object]",
+  },
+);
 // function (toString)
 assertDeepEqual(
   testSerialize(

--- a/components/service/default/index.mjs
+++ b/components/service/default/index.mjs
@@ -19,7 +19,7 @@ export default (dependencies) => {
         sockets.add(socket);
         /* c8 ignore start */
         socket.on("error", (error) => {
-          logWarning("Socket error >> %e", error);
+          logWarning("Socket error >> %O", error);
         });
         /* c8 ignore stop */
         socket.on("close", () => {

--- a/components/source-outer/node/index.mjs
+++ b/components/source-outer/node/index.mjs
@@ -2,7 +2,7 @@ import File from "./file.mjs";
 
 export default (dependencies) => {
   const {
-    log: { logWarning },
+    log: { logDebug, logWarning },
     util: { isLeft, fromLeft, fromRight },
     source: {
       extractSourceMapURL,
@@ -19,9 +19,10 @@ export default (dependencies) => {
       if (source_map_url === null) {
         return createMirrorSourceMap(file);
       }
+      const log = file.url.includes("/node_modules/") ? logDebug : logWarning;
       const either = readFileSync(source_map_url, file.url);
       if (isLeft(either)) {
-        logWarning(
+        log(
           "Cannot read source map file %j\n  Referenced in script file at %j\n  >> %s",
           source_map_url,
           file.url,
@@ -35,7 +36,7 @@ export default (dependencies) => {
         if (content === null) {
           const either = readFileSync(url, source_map_file.url);
           if (isLeft(either)) {
-            logWarning(
+            log(
               "Cannot read source file %j\n  Referenced in source map file %j\n  Referenced in script file %j\n  >> %s",
               url,
               source_map_url,

--- a/components/source-outer/node/index.test.mjs
+++ b/components/source-outer/node/index.test.mjs
@@ -20,6 +20,16 @@ const { extractSourceMap } = SourceOuter(
 }
 
 {
+  const file = {
+    url: `${getFreshTemporaryURL()}/node_modules/${Math.random()
+      .toString(36)
+      .substring()}`,
+    content: "123; //# sourceMappingURL=source.map",
+  };
+  assertDeepEqual(getSources(extractSourceMap(file)), [file]);
+}
+
+{
   const url = getFreshTemporaryURL();
   await mkdirAsync(new URL(url));
   const file = {
@@ -36,7 +46,6 @@ const { extractSourceMap } = SourceOuter(
       content: "456;",
     },
   ];
-  assertDeepEqual(getSources(extractSourceMap(file)), [file]);
   await writeFileAsync(
     new URL(`${url}/source.map`),
     JSON.stringify({

--- a/components/source/default/index.mjs
+++ b/components/source/default/index.mjs
@@ -76,7 +76,7 @@ export default (dependencies) => {
         url,
         expectSuccess(
           () => parseJSON(content),
-          "Invalid JSON format for source map at %j >> %e",
+          "Invalid JSON format for source map at %j >> %O",
           url,
         ),
       );

--- a/components/specifier/default/index.mjs
+++ b/components/specifier/default/index.mjs
@@ -21,7 +21,7 @@ export default (dependencies) => {
     } else {
       const regexp = expectSuccess(
         () => new _RegExp(source, flags),
-        "failed to compile regexp source = %j flags = %j >> %e",
+        "failed to compile regexp source = %j flags = %j >> %O",
         source,
         flags,
       );

--- a/components/trace/appmap/classmap/estree/parse.mjs
+++ b/components/trace/appmap/classmap/estree/parse.mjs
@@ -60,12 +60,12 @@ export default (dependencies) => {
           attachComment: true,
         });
       } catch (error) {
-        logError("Unrecoverable parsing error at file %j >> %e", path, error);
+        logError("Unrecoverable parsing error at file %j >> %O", path, error);
         return { type: "Program", body: [], sourceType: "script" };
       }
       const { errors, program: node } = result;
       for (const error of errors) {
-        logWarning("Recoverable parsing error at file %j >> %e", path, error);
+        logWarning("Recoverable parsing error at file %j >> %O", path, error);
       }
       return node;
     },

--- a/components/util/default/format.mjs
+++ b/components/util/default/format.mjs
@@ -1,8 +1,7 @@
 import { assert } from "./assert.mjs";
 import { print } from "./print.mjs";
 
-const { getOwnPropertyDescriptor } = Reflect;
-const _undefined = undefined;
+const _String = String;
 const { stringify } = JSON;
 
 export const format = (template, values) => {
@@ -21,26 +20,15 @@ export const format = (template, values) => {
         assert(typeof value === "string", "expected a string for format");
         return value;
       }
-      if (marker === "e") {
-        assert(
-          typeof value === "object" && value !== null,
-          "expected an object",
-        );
-        const descriptor = getOwnPropertyDescriptor(value, "message");
-        assert(descriptor !== _undefined, "missing 'message' property");
-        assert(
-          getOwnPropertyDescriptor(descriptor, "value") !== _undefined,
-          "'message' property is an accessor",
-        );
-        const { value: message } = descriptor;
-        assert(
-          typeof message === "string",
-          "expected 'message' property value to be a string",
-        );
-        return message;
-      }
       if (marker === "j") {
         return stringify(value);
+      }
+      if (marker === "O") {
+        try {
+          return _String(value);
+        } catch {
+          return print(value);
+        }
       }
       if (marker === "o") {
         return print(value);

--- a/components/util/default/format.test.mjs
+++ b/components/util/default/format.test.mjs
@@ -28,18 +28,17 @@ assertEqual(format("%j", [[123]]), "[123]");
 
 assertEqual(format("%o", [() => {}]), "[object Function]");
 
-// %e //
+// %O //
 
-assertEqual(format("%e", [new Error("foo")]), "foo");
+assertEqual(format("%O", [{ toString: () => "foo" }]), "foo");
 
-assertThrow(() => format("%e", [null]), /^AssertionError: expected an object/u);
-
-assertThrow(
-  () => format("%e", [{}]),
-  /^AssertionError: missing 'message' property/u,
-);
-
-assertThrow(
-  () => format("%e", [{ message: 123 }]),
-  /^AssertionError: expected 'message' property value to be a string/u,
+assertEqual(
+  format("%O", [
+    {
+      toString: () => {
+        throw new Error("BOUM");
+      },
+    },
+  ]),
+  "[object Object]",
 );

--- a/components/validate-appmap/on/index.mjs
+++ b/components/validate-appmap/on/index.mjs
@@ -10,7 +10,7 @@ export default (dependencies) => {
     validateAppmap: (data) => {
       expectSuccess(
         () => validateAppmap(data, { version: "1.6.0" }),
-        "failed to validate appmap\n%j\n%e",
+        "failed to validate appmap\n%j\n%O",
         data,
       );
     },

--- a/lib/node/__common__.mjs
+++ b/lib/node/__common__.mjs
@@ -21,6 +21,6 @@ if (configuration.socket === "unix") {
   }
 }
 const { log } = configuration;
-const { createLoaderHooks } = Loader({ log });
+const { createLoaderHooks } = Loader({ log: log.level });
 export const { transformSourceAsync: transformSource, loadAsync: load } =
   createLoaderHooks();

--- a/lib/node/batch.mjs
+++ b/lib/node/batch.mjs
@@ -7,8 +7,9 @@ const {
   log,
   validate: { message: validate_message, appmap: validate_appmap },
 } = configuration;
+process.env.APPMAP_LOG_FILE = JSON.stringify(log.file);
 const { mainAsync } = Batch({
-  log,
+  log: log.level,
   "validate-appmap": validate_appmap ? "on" : "off",
   "validate-message": validate_message ? "on" : "off",
 });

--- a/lib/node/mocha-loader.mjs
+++ b/lib/node/mocha-loader.mjs
@@ -1,8 +1,9 @@
 import { configuration } from "./__common__.mjs";
-const { log } = configuration;
 import ValidateMocha from "../../dist/node/validate-mocha.mjs";
 import Mocha from "mocha";
-const { validateMocha } = ValidateMocha({ log });
+const { log } = configuration;
+process.env.APPMAP_LOG_FILE = JSON.stringify(log.file);
+const { validateMocha } = ValidateMocha({ log: log.level });
 validateMocha(Mocha);
 
 export { transformSource, load } from "./__common__.mjs";

--- a/lib/node/recorder-api.mjs
+++ b/lib/node/recorder-api.mjs
@@ -20,8 +20,9 @@ export const createAppMap = (home = url, conf = {}, base = url) => {
     log,
     validate: { message: validate_message, appmap: validate_appmap },
   } = configuration;
+  process.env.APPMAP_LOG_FILE = JSON.stringify(log.file);
   const { Appmap } = Recorder({
-    log,
+    log: log.level,
     "validate-message": validate_message ? "on" : "off",
     "validate-appmap": validate_appmap ? "on" : "off",
   });

--- a/lib/node/recorder-mocha.mjs
+++ b/lib/node/recorder-mocha.mjs
@@ -1,5 +1,6 @@
 import { configuration } from "./__common__.mjs";
 import RecorderMocha from "../../dist/node/recorder-mocha.mjs";
 const { log, socket } = configuration;
-const { createMochaHooks } = RecorderMocha({ log, socket });
+process.env.APPMAP_LOG_FILE = JSON.stringify(log.file);
+const { createMochaHooks } = RecorderMocha({ log: log.level, socket });
 export const mochaHooks = createMochaHooks(process, configuration);

--- a/lib/node/recorder-process.mjs
+++ b/lib/node/recorder-process.mjs
@@ -2,6 +2,7 @@ import { configuration } from "./__common__.mjs";
 import RecorderProcess from "../../dist/node/recorder-process.mjs";
 
 const { log, socket } = configuration;
-const { main } = RecorderProcess({ log, socket });
+process.env.APPMAP_LOG_FILE = JSON.stringify(log.file);
+const { main } = RecorderProcess({ log: log.level, socket });
 main(process, configuration);
 export { transformSource, load } from "./__common__.mjs";

--- a/lib/node/recorder-remote.mjs
+++ b/lib/node/recorder-remote.mjs
@@ -2,6 +2,7 @@ import { configuration } from "./__common__.mjs";
 import RecorderRemote from "../../dist/node/recorder-remote.mjs";
 
 const { log, socket } = configuration;
-const { main } = RecorderRemote({ log, socket });
+process.env.APPMAP_LOG_FILE = JSON.stringify(log.file);
+const { main } = RecorderRemote({ log: log.level, socket });
 main(process, configuration);
 export { transformSource, load } from "./__common__.mjs";


### PR DESCRIPTION
* Demote/remove the most verbose warnings
* New `%O` format marker that replaces `%e`
* Support for top-level await
* Handle the case where `toString` methods do not actually return a string