### PR TITLE
fix: use write instead of end to show results

### DIFF
--- a/components/init/node/index.mjs
+++ b/components/init/node/index.mjs
@@ -10,8 +10,14 @@ const GLOB = "!(node_modules)/";
 /* c8 ignore start */
 export const externals = {
   async showResults(s) {
-    return new Promise((resolve) => {
-      process.stdout.end(s, () => resolve());
+    return new Promise((resolve, reject) => {
+      process.stdout.write(s, (error) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
     });
   },
 };

--- a/components/status/node/index.mjs
+++ b/components/status/node/index.mjs
@@ -21,8 +21,14 @@ export const externals = {
   },
 
   async showResults(s) {
-    return new Promise((resolve) => {
-      process.stdout.end(s, () => resolve());
+    return new Promise((resolve, reject) => {
+      process.stdout.write(s, (error) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
     });
   },
 


### PR DESCRIPTION
Using `process.stdout.end` may disturb the normal closing of the node process. It is safer to use `process.stdout.write`.