### PR TITLE
Removing Node 17 from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 Supported platforms:
 * Unix-like os, tested on Linux and macOS; Windows is currently not supported
-* Node.js 14, 16, 17
+* Node.js 14 or 16
 * Express.js
 * git is highly recommended 
 * mocha >= 8.0.0 is requried for recording AppMaps from test cases (earlier versions do not support required root hooks)


### PR DESCRIPTION
When Node 18 is verified, we will add that back in. But for now, Node 17 is problematic, so I'm removing it from the README.