### PR TITLE
fix: use static path in function path

### DIFF
--- a/test/cases/apply-async/appmap.yml
+++ b/test/cases/apply-async/appmap.yml
@@ -14,3 +14,5 @@ hooks:
   mysql: false
   pg: false
   sqlite3: false
+validate:
+  appmap: true

--- a/test/cases/apply-generator/appmap.yml
+++ b/test/cases/apply-generator/appmap.yml
@@ -14,3 +14,5 @@ hooks:
   mysql: false
   pg: false
   sqlite3: false
+validate:
+  appmap: true

--- a/test/cases/apply-mismatch/appmap.yml
+++ b/test/cases/apply-mismatch/appmap.yml
@@ -14,3 +14,5 @@ hooks:
   mysql: false
   pg: false
   sqlite3: false
+validate:
+  appmap: true

--- a/test/cases/apply-pattern/appmap.yml
+++ b/test/cases/apply-pattern/appmap.yml
@@ -14,3 +14,5 @@ hooks:
   mysql: false
   pg: false
   sqlite3: false
+validate:
+  appmap: true

--- a/test/cases/apply-rest/appmap.yml
+++ b/test/cases/apply-rest/appmap.yml
@@ -14,3 +14,5 @@ hooks:
   mysql: false
   pg: false
   sqlite3: false
+validate:
+  appmap: true

--- a/test/cases/apply-source/appmap.yml
+++ b/test/cases/apply-source/appmap.yml
@@ -18,3 +18,5 @@ hooks:
   mysql: false
   pg: false
   sqlite3: false
+validate:
+  appmap: true

--- a/test/cases/classmap/appmap.yml
+++ b/test/cases/classmap/appmap.yml
@@ -14,3 +14,5 @@ hooks:
   mysql: false
   pg: false
   sqlite3: false
+validate:
+  appmap: true

--- a/test/cases/default-parameter/appmap.yml
+++ b/test/cases/default-parameter/appmap.yml
@@ -14,3 +14,5 @@ hooks:
   mysql: false
   pg: false
   sqlite3: false
+validate:
+  appmap: true

--- a/test/cases/env-var/appmap.yml
+++ b/test/cases/env-var/appmap.yml
@@ -16,3 +16,5 @@ hooks:
   mysql: false
   pg: false
   sqlite3: false
+validate:
+  appmap: true

--- a/test/cases/eval/appmap.yml
+++ b/test/cases/eval/appmap.yml
@@ -15,3 +15,5 @@ hooks:
   mysql: false
   pg: false
   sqlite3: false
+validate:
+  appmap: true

--- a/test/cases/generator-method/appmap.yml
+++ b/test/cases/generator-method/appmap.yml
@@ -14,3 +14,5 @@ hooks:
   mysql: false
   pg: false
   sqlite3: false
+validate:
+  appmap: true

--- a/test/cases/html/appmap.yml
+++ b/test/cases/html/appmap.yml
@@ -18,3 +18,5 @@ hooks:
   mysql: false
   pg: false
   sqlite3: false
+validate:
+  appmap: true

--- a/test/cases/http/appmap.yml
+++ b/test/cases/http/appmap.yml
@@ -14,3 +14,5 @@ hooks:
   mysql: false
   pg: false
   sqlite3: false
+validate:
+  appmap: true

--- a/test/cases/jest-json/appmap.yml
+++ b/test/cases/jest-json/appmap.yml
@@ -14,3 +14,5 @@ hooks:
   mysql: false
   pg: false
   sqlite3: false
+validate:
+  appmap: true

--- a/test/cases/jest-transformer-preset/appmap.yml
+++ b/test/cases/jest-transformer-preset/appmap.yml
@@ -14,3 +14,5 @@ hooks:
   mysql: false
   pg: false
   sqlite3: false
+validate:
+  appmap: true

--- a/test/cases/jest-transformer/appmap.yml
+++ b/test/cases/jest-transformer/appmap.yml
@@ -14,3 +14,5 @@ hooks:
   mysql: false
   pg: false
   sqlite3: false
+validate:
+  appmap: true

--- a/test/cases/jest/appmap.yml
+++ b/test/cases/jest/appmap.yml
@@ -14,3 +14,5 @@ hooks:
   mysql: false
   pg: false
   sqlite3: false
+validate:
+  appmap: true

--- a/test/cases/metadata/appmap.yml
+++ b/test/cases/metadata/appmap.yml
@@ -16,3 +16,5 @@ hooks:
   mysql: false
   pg: false
   sqlite3: false
+validate:
+  appmap: true

--- a/test/cases/mocha/appmap.yml
+++ b/test/cases/mocha/appmap.yml
@@ -14,3 +14,5 @@ hooks:
   mysql: false
   pg: false
   sqlite3: false
+validate:
+  appmap: true

--- a/test/cases/npx/appmap.yml
+++ b/test/cases/npx/appmap.yml
@@ -21,3 +21,5 @@ hooks:
   mysql: false
   pg: false
   sqlite3: false
+validate:
+  appmap: true

--- a/test/cases/query/appmap.yml
+++ b/test/cases/query/appmap.yml
@@ -14,3 +14,5 @@ hooks:
   mysql: false
   pg: false
   sqlite3: true
+validate:
+  appmap: true

--- a/test/cases/to-string/appmap.yml
+++ b/test/cases/to-string/appmap.yml
@@ -14,3 +14,5 @@ hooks:
   mysql: false
   pg: false
   sqlite3: false
+validate:
+  appmap: true

--- a/test/cases/ts-node-esm/appmap.yml
+++ b/test/cases/ts-node-esm/appmap.yml
@@ -21,3 +21,5 @@ hooks:
   mysql: false
   pg: false
   sqlite3: false
+validate:
+  appmap: true

--- a/test/cases/version/appmap.yml
+++ b/test/cases/version/appmap.yml
@@ -1,1 +1,2 @@
-{}
+validate:
+  appmap: true


### PR DESCRIPTION
When there is only one version of a file available, we should use the static path format. This was already the case in the classmap but not in the event section. I added validation in tests to prevent regressions.